### PR TITLE
Fix Icon in Wayland

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "whatsapp-electron",
+  "desktopName": "com.github.dagmoller.whatsapp-electron",
   "version": "1.2.5",
   "description": "DagMoller's WhatsApp Electron Multi-Account App",
   "author": "Diego Aguirre (DagMoller)",


### PR DESCRIPTION
Fixes icon display on wayland due to different .desktop file name.

Same as https://github.com/digimezzo/dopamine/pull/923